### PR TITLE
Responsified Calendar Footer

### DIFF
--- a/src/components/calendar/SkeletonSkatingCalendar.tsx
+++ b/src/components/calendar/SkeletonSkatingCalendar.tsx
@@ -5,16 +5,16 @@ import CalendarSkater from "../../../public/assets/CalendarSkeleton.svg";
 
 const SkeletonSkaterCalendar = () => {
   return (
-    <div className="flex flex-col items-center justify-center">
+    <div className="flex flex-col items-center justify-center pt-28 md:p-0 lg:pt-28">
       <Image
         src={CalendarSkater}
         alt="skating skeleton"
-        className="bottom-10 z-10 size-1/4 translate-y-[170%] transform object-center lg:bottom-56 lg:size-1/6 lg:translate-y-[90%]"
+        className="bottom-10 z-10 size-1/4 translate-y-[20%] transform object-center lg:bottom-56 lg:size-1/6 lg:translate-y-[30%]"
       />
       <Image
         src={CalendarRamp}
         alt="skating ramp"
-        className="bottom-0 w-full translate-y-[210%] object-center lg:translate-y-[50%]"
+        className="bottom-0 w-full translate-y-[0%] object-center lg:translate-y-[0%]"
       />
     </div>
   );


### PR DESCRIPTION
Responsified the Calendar page. Made the skeleton/ramp above the footer for both mobile and larger screens. Added padding for certain devices that had the skeleton clip through the calendar. May have made certain devices have too much space between the calendar and the skeleton/ramp. 

![image](https://github.com/user-attachments/assets/452182c0-f113-4a3f-b245-3aa98d871fa2)

![image](https://github.com/user-attachments/assets/1b536496-e7ca-4dd3-80e8-dc45865187db)

![image](https://github.com/user-attachments/assets/f2271864-d21e-40a4-a37f-37289c5be88e)

